### PR TITLE
Added getFirstRowWhere for predicates and matchers for Tables.

### DIFF
--- a/src/main/java/com/redhat/darcy/ui/api/elements/Table.java
+++ b/src/main/java/com/redhat/darcy/ui/api/elements/Table.java
@@ -30,6 +30,7 @@ import org.hamcrest.Matcher;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Spliterators;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -164,11 +165,27 @@ public interface Table<T extends Table<T>> extends ViewElement {
     }
 
     /**
+     * @return The first filtered {@link java.util.Optional} of the rows in this table where the
+     * contents of a particular column match the specified {@link java.util.function.Predicate}.
+     */
+    default <U> Optional<Row<T>> getFirstRowWhere(Column<T, U> column, Predicate<? super U> predicate) {
+        return getRowsWhere(column, predicate).findFirst();
+    }
+
+    /**
      * @return A filtered {@link java.util.stream.Stream} of the rows in this table where the
      * contents of a particular column match the specified Hamcrest {@link org.hamcrest.Matcher}.
      */
     default <U> Stream<Row<T>> getRowsWhere(Column<T, U> column, Matcher<? super U> matcher) {
         return getRowsWhere(column, matcher::matches);
+    }
+
+    /**
+     * @return The first filtered {@link java.util.Optional} of the rows in this table where the
+     * contents of a particular column match the specified Hamcrest {@link org.hamcrest.Matcher}.
+     */
+    default <U> Optional<Row<T>> getFirstRowWhere(Column<T, U> column, Matcher<? super U> matcher) {
+        return getRowsWhere(column, matcher::matches).findFirst();
     }
 
     /**

--- a/src/test/java/com/redhat/darcy/ui/api/elements/TableTest.java
+++ b/src/test/java/com/redhat/darcy/ui/api/elements/TableTest.java
@@ -34,6 +34,7 @@ import org.junit.runners.JUnit4;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RunWith(JUnit4.class)
@@ -143,6 +144,23 @@ public class TableTest {
     }
 
     @Test
+    public void shouldGetFirstRowWhereWithPredicateInOrder() {
+        Table.Column<StubTable, Integer> testColumn = (t, r) -> r;
+        StubTable testTable = new StubTable() {
+            @Override
+            public int getRowCount() {
+                return 50;
+            }
+        };
+
+        Optional<Table.Row<StubTable>> row = testTable.getFirstRowWhere(testColumn, i -> i > 10);
+
+        int curRow = 11;
+        assertThat(row.get().getIndex(), equalTo(curRow));
+        assertSame(testTable, row.get().getTable());
+    }
+
+    @Test
     public void shouldGetRowsWhereWithMatcherInOrder() {
         Table.Column<StubTable, Integer> testColumn = (t, r) -> r;
         StubTable testTable = new StubTable() {
@@ -166,6 +184,23 @@ public class TableTest {
         }
 
         assertThat("Did not return all rows that satisfied matcher.", curRow, equalTo(50));
+    }
+
+    @Test
+    public void shouldGetFirstRowWhereWithMatcherInOrder() {
+        Table.Column<StubTable, Integer> testColumn = (t, r) -> r;
+        StubTable testTable = new StubTable() {
+            @Override
+            public int getRowCount() {
+                return 50;
+            }
+        };
+
+        Optional<Table.Row<StubTable>> row = testTable.getFirstRowWhere(testColumn, greaterThan(10));
+
+        int curRow = 11;
+        assertThat(row.get().getIndex(), equalTo(curRow));
+        assertSame(testTable, row.get().getTable());
     }
 
     @Test


### PR DESCRIPTION
The quick and dirty version.  I think it might be more beneficial to provide a hint to the predicate and/or matcher to specify that we're only looking for one run, so that it doesn't build the collection and just grab the first row.  Any thoughts?
